### PR TITLE
Create safe and unsafe HTML files for emails

### DIFF
--- a/EmailsToTelegramService/src/main/java/io/github/trashemail/EmailsToTelegramService/ForwardMailsToTelegram.java
+++ b/EmailsToTelegramService/src/main/java/io/github/trashemail/EmailsToTelegramService/ForwardMailsToTelegram.java
@@ -91,7 +91,7 @@ public class ForwardMailsToTelegram {
                 if (filename != null)
                     sendTelegramMessage.sendMessage(parsedMail.toString(),
                             chatId,
-                            (String) filename);
+                            (String[]) filename);
                 else {
                     sendTelegramMessage.sendMessage(parsedMail.toString(),
                             chatId);

--- a/EmailsToTelegramService/src/main/java/io/github/trashemail/EmailsToTelegramService/SendTelegramMessage.java
+++ b/EmailsToTelegramService/src/main/java/io/github/trashemail/EmailsToTelegramService/SendTelegramMessage.java
@@ -61,7 +61,7 @@ public class SendTelegramMessage {
     }
 
     @Async
-    public void sendMessage(String message, long chatId, String filename) {
+    public void sendMessage(String message, long chatId, String[] filename) {
         String telegramURI = imapClientServiceConfig.getTelegram().getUrl() +
                 imapClientServiceConfig.getTelegram().getBotToken() +
                 "/sendMessage";
@@ -93,16 +93,23 @@ public class SendTelegramMessage {
             */
             InlineKeyboardMarkup markupKeyboard = new InlineKeyboardMarkup();
 
-            InlineKeyboardButton keyboardButton = new InlineKeyboardButton();
-            keyboardButton.setText("HTML version");
-            keyboardButton.setUrl(
+            InlineKeyboardButton keyboardButtonSafeHTML = new InlineKeyboardButton();
+            keyboardButtonSafeHTML.setText("Safe HTML version");
+            keyboardButtonSafeHTML.setUrl(
                     imapClientServiceConfig.getEmails().getHostPath() +
-                            filename);
+                            filename[0]);
+
+            InlineKeyboardButton keyboardButtonUnSafeHTML = new InlineKeyboardButton();
+            keyboardButtonUnSafeHTML.setText("Unsafe HTML version");
+            keyboardButtonUnSafeHTML.setUrl(
+                    imapClientServiceConfig.getEmails().getHostPath() +
+                            filename[1]);
 
             List<List<InlineKeyboardButton>> buttonList = new ArrayList<>();
 
             buttonList.add(new ArrayList<>());
-            buttonList.get(0).add(keyboardButton);
+            buttonList.get(0).add(keyboardButtonSafeHTML);
+            buttonList.get(0).add(keyboardButtonUnSafeHTML);
 
             markupKeyboard.setInlineKeyboardButtonList(buttonList);
 

--- a/EmailsToTelegramService/src/main/java/io/github/trashemail/EmailsToTelegramService/utils/SaveMailToHTMLFile.java
+++ b/EmailsToTelegramService/src/main/java/io/github/trashemail/EmailsToTelegramService/utils/SaveMailToHTMLFile.java
@@ -17,22 +17,32 @@ public class SaveMailToHTMLFile {
     private static final Logger log = LoggerFactory.getLogger(
             SaveMailToHTMLFile.class);
 
-    public Object saveToFile(String htmlContent){
+    private static String safeHTMLCSPPolicy = "<meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'self';style-src 'unsafe-inline';img-src 'self' data:\">";
+
+    public Object saveToFile(String htmlContent) {
         try {
-            String filename = UUID.randomUUID().toString() + ".html";
+            String safeHTMLFilename = UUID.randomUUID().toString() + "_safe" + ".html";
+            String UnSafeHTMLFilename = UUID.randomUUID().toString() + "_unsafe" + ".html";
 
             FileWriter myWriter = new FileWriter(
                     imapClientServiceConfig
                             .getEmails()
-                            .getDownloadPath() + filename);
+                            .getDownloadPath() + safeHTMLFilename);
+            myWriter.write(safeHTMLCSPPolicy + htmlContent);
+            myWriter.close();
+            log.debug("File written to disk: " + safeHTMLFilename);
+
+            myWriter = new FileWriter(
+                    imapClientServiceConfig
+                            .getEmails()
+                            .getDownloadPath() + UnSafeHTMLFilename);
 
             myWriter.write(htmlContent);
             myWriter.close();
+            log.debug("File written to disk: " + UnSafeHTMLFilename);
 
-            log.debug("File written to disk: "+ filename);
-            return filename;
-        }
-        catch (Exception e) {
+            return new String[]{safeHTMLFilename, UnSafeHTMLFilename};
+        } catch (Exception e) {
             log.error("Unable to save to HTML file. " + e.getMessage());
             return null;
         }


### PR DESCRIPTION
Safe version of email will block remote resources for privacy and security but may display crippled version of email, unsafe version will be as is copy of email without CSP. Possible fix for https://github.com/TrashEmail/TrashEmail/issues/59  