### PR TITLE
Logging arguments should not require evaluation and printf-style format strings.

### DIFF
--- a/TrashEmailService/src/main/java/io/github/trashemail/EmailServerInteraction.java
+++ b/TrashEmailService/src/main/java/io/github/trashemail/EmailServerInteraction.java
@@ -54,7 +54,9 @@ public class EmailServerInteraction {
 					"successfully Created :)";
 		}
 
-		log.error(response.getStatusCode().toString() + response.getBody());
+		if (log.isErrorEnabled())
+			log.error("{} {}", response.getStatusCode(), response.getBody());
+
 		throw new EmailAliasNotCreatedExecption(response.getBody().toString());
 	}
 


### PR DESCRIPTION
Avoid processing with logging disabled.
If the body is null, as it was, the log print would just be null, because of string concatenation.

https://sonarcloud.io/organizations/r0hi7/rules?open=java%3AS2629&rule_key=java%3AS2629
https://sonarcloud.io/organizations/r0hi7/rules?open=java%3AS3457&rule_key=java%3AS3457
